### PR TITLE
Improve drag mobile support

### DIFF
--- a/style.css
+++ b/style.css
@@ -463,6 +463,14 @@ body.ai-ready .ai-feature {
     box-sizing: border-box;
     background-color: transparent; /* Inherit card background */
 }
+
+body.dragging-cards .card-content {
+    padding: 4px;
+}
+
+body.dragging-cards .card {
+    margin-bottom: 4px;
+}
 .card-content.ai-loading {
     font-style: italic;
     color: #555;
@@ -528,6 +536,14 @@ body.ai-ready .ai-feature {
 /* --- Utility --- */
 .hidden {
     display: none !important;
+}
+
+.clamp-3-lines,
+body.dragging-cards .card-content {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3; /* Show at most 3 lines */
 }
 
 /* --- Modal (Simple Placeholder) --- */


### PR DESCRIPTION
## Summary
- use setCompactMode() to toggle card height adjustments
- extract attachTouchDragSupport() for cleaner touch events
- add reusable `.clamp-3-lines` utility and apply to drag mode

## Testing
- `node --check dragDrop.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_684c365212f48326a9ce9d23e048e27b